### PR TITLE
Fixing incorrect comments in CMakeLists.txt for private_copies

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/src/CMakeLists.txt
@@ -27,24 +27,18 @@ endif()
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
 set(EMULATOR_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(AOC_SEED_FLAG "-Xsseed=4 -Xsparallel=2") # Special flags passed to to Quartus®
 set(HARDWARE_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fintelfpga")
-if(FPGA_BOARD STREQUAL "intel_a10gx_pac:pac_a10")
-    # hyper-optimized-handshaking does not apply to Intel Arria® 10 FPGAs
-    set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${AOC_SEED_FLAG} ${USER_HARDWARE_FLAGS}")
-else()
-    set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xshyper-optimized-handshaking=off -Xsboard=${FPGA_BOARD} ${AOC_SEED_FLAG} ${USER_HARDWARE_FLAGS}")
-endif()
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
 ###############################################################################
 ### FPGA Emulator
 ###############################################################################
 # To compile in a single command:
-#    dpcpp -fintelfpga -DFPGA_EMULATOR lsu_control.cpp -o lsu_control.fpga_emu
+#    dpcpp -fintelfpga -DFPGA_EMULATOR private_copies.cpp -o private_copies.fpga_emu
 # CMake executes:
-#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o lsu_control.cpp.o -c lsu_control.cpp
-#    [link]    dpcpp -fintelfpga lsu_control.cpp.o -o lsu_control.fpga_emu
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o private_copies.cpp.o -c private_copies.cpp
+#    [link]    dpcpp -fintelfpga private_copies.cpp.o -o private_copies.fpga_emu
 add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
 set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
 set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
@@ -54,7 +48,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### Generate Report
 ###############################################################################
 # To compile manually:
-#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -Xsseed=4 -Xsparallel=2 -fsycl-link=early lsu_control.cpp -o lsu_control_report.a
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early private_copies.cpp -o private_copies_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 # The compile output is not an executable, but an intermediate compilation result unique to DPC++.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
@@ -67,10 +61,10 @@ set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK
 ### FPGA Hardware
 ###############################################################################
 # To compile in a single command:
-#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -Xsseed=4 -Xsparallel=2 lsu_control.cpp -o lsu_control.fpga
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> private_copies.cpp -o private_copies.fpga
 # CMake executes:
-#   [compile] dpcpp -fintelfpga -o lsu_control.cpp.o -c lsu_control.cpp
-#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -Xsseed=4 -Xsparallel=2 lsu_control.cpp.o -o lsu_control.fpga
+#   [compile] dpcpp -fintelfpga -o private_copies.cpp.o -c private_copies.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> private_copies.cpp.o -o private_copies.fpga
 add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 add_custom_target(fpga DEPENDS ${FPGA_TARGET})
 set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")


### PR DESCRIPTION
Also, removing some unnecessary flags that were likely kept around
from when Justin copied this tutorial from lsu_control

Signed-off-by: mohammadfawaz <mohammad.fawaz@intel.com>

# Existing Sample Changes
## Description

Fixing incorrect comments in CMakeLists.txt for private_copies and removing 
some unnecessary flags that were likely kept aroundfrom when Justin copied 
this tutorial from lsu_control

## External Dependencies

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
